### PR TITLE
Test for JSINFO.folded in script.js, prevents javascript failure when…

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@
 jQuery(function() {
     // containers for localised reveal/hide strings,
     // populated from the content set by the action plugin
+    if(!JSINFO || !JSINFO['plugin_folded']) return;
     var folded_reveal = JSINFO['plugin_folded']['reveal'];
     var folded_hide = JSINFO['plugin_folded']['hide'];
 


### PR DESCRIPTION
… not defined in folded plugin that activate pop-ups.  When not defined in folded, the pop-up is corrupted by the Javascript failure.
