### PR TITLE
__medium__ is not a standard LESS placeholder

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,11 +10,11 @@
 
 div.folded {
     padding: 0.5em;
-    border: 1px dotted __medium__;
+    border: 1px dotted __border__;
 }
 
 span.folded {
-    border: 1px dotted __medium__;
+    border: 1px dotted __border__;
 }
 
 span.indicator {


### PR DESCRIPTION
Replacing __medium__ with __border__ seems more bullet proof :)