### PR TITLE
Fix invalid HTML id attribute in case of multibyte page names.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -25,8 +25,9 @@ class helper_plugin_folded extends DokuWiki_Plugin {
     function getNextID() {
         global $ID;
 
+        $hash = md5($ID);
         $this->ids_count++;
-        $id = 'folded_'.$ID.'_'.$this->ids_count;
+        $id = 'folded_'.$hash.'_'.$this->ids_count;
         return $id;
     }
 }


### PR DESCRIPTION
Use an md5 hash of the page ID to guarantee ASCII signs in HTML id attribute. Fixes #52.