### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/syntax/div.php
+++ b/syntax/div.php
@@ -21,7 +21,7 @@ if (!isset($plugin_folded_string_set)) $plugin_folded_string_set = false;
  * need to inherit from this class
  */
 class syntax_plugin_folded_div extends DokuWiki_Syntax_Plugin {
-    protected $helper = NULL;
+    protected $helper = null;
 
     function getType(){ return 'container'; }
     function getPType() { return 'stack'; }
@@ -53,7 +53,7 @@ class syntax_plugin_folded_div extends DokuWiki_Syntax_Plugin {
         if($mode == 'xhtml') {
             switch ($state){
               case DOKU_LEXER_ENTER:
-                if ($this->helper === NULL) {
+                if ($this->helper === null) {
                     $this->helper = plugin_load('helper', 'folded');
                 }
                 $folded_id = $this->helper->getNextID();

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -51,7 +51,7 @@ class syntax_plugin_folded_span extends DokuWiki_Syntax_Plugin {
         if($mode == 'xhtml') {
             switch ($state){
                case DOKU_LEXER_ENTER:
-                if ($this->helper === NULL) {
+                if ($this->helper === null) {
                     $this->helper = plugin_load('helper', 'folded');
                 }
                 $folded_id = $this->helper->getNextID();


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!