### PR TITLE
Make hash in HTML id unique by including the current action

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -25,7 +25,14 @@ class helper_plugin_folded extends DokuWiki_Plugin {
     function getNextID() {
         global $ID;
 
-        $hash = md5($ID);
+        $router = \dokuwiki\ActionRouter::getInstance();
+        try {
+            $action = '!!!'.$router->getAction()->getActionName().'!!!';
+        } catch(\dokuwiki\Action\Exception\FatalException $e) {
+            $action = '';
+        }
+
+        $hash = md5($ID.$action);
         $this->ids_count++;
         $id = 'folded_'.$hash.'_'.$this->ids_count;
         return $id;


### PR DESCRIPTION
This fixes duplicate HTML ids on usage of the folded plugin in different parts of DokuWiki. E.g. in the page content and editor UI. Fixes #54.