### PR TITLE
Fix PHP warnings

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -5,8 +5,6 @@
  */
 
 class helper_plugin_folded extends DokuWiki_Plugin {
-    static protected $ids_count = 0;
-
     function getMethods() {
         $result = array();
         $result[] = array(
@@ -20,6 +18,7 @@ class helper_plugin_folded extends DokuWiki_Plugin {
      * Returns the next folded ID.
      */
     function getNextID() {
+        static $ids_count = 0;
         global $ID, $ACT;
 
         $hash = md5($ID.$ACT);

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -14,6 +14,9 @@
  */
 class syntax_plugin_folded_span extends DokuWiki_Syntax_Plugin {
 
+    /** @var helper_plugin_folded */
+    protected $helper = null;
+
     function getType(){ return 'formatting'; }
     function getAllowedTypes() { return array('substition','protected','disabled','formatting'); }
     function getSort(){ return 405; }
@@ -43,7 +46,7 @@ class syntax_plugin_folded_span extends DokuWiki_Syntax_Plugin {
         if($mode == 'xhtml') {
             switch ($state){
                case DOKU_LEXER_ENTER:
-                if (!isset($this->helper)) {
+                if ($this->helper === null) {
                     $this->helper = plugin_load('helper', 'folded');
                 }
                 $folded_id = $this->helper->getNextID();

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -43,7 +43,7 @@ class syntax_plugin_folded_span extends DokuWiki_Syntax_Plugin {
         if($mode == 'xhtml') {
             switch ($state){
                case DOKU_LEXER_ENTER:
-                if ($this->helper === null) {
+                if (!isset($this->helper)) {
                     $this->helper = plugin_load('helper', 'folded');
                 }
                 $folded_id = $this->helper->getNextID();


### PR DESCRIPTION
See #76 

Note that while the fix in https://github.com/dokufreaks/plugin-folded//master/syntax/span.php#L46 (https://github.com/fiwswe/plugin-folded/commit/ff9160f90c517971c0fd2a9c893d3e8fe16e3997) does fix the observed warning, I think the check for the `helper` property should possibly be done at the start of the function as it is used several times?