### PR TITLE
Fix  _addCall deprecation Warnings

### DIFF
--- a/syntax/div.php
+++ b/syntax/div.php
@@ -29,7 +29,7 @@ class syntax_plugin_folded_div extends DokuWiki_Syntax_Plugin {
         if ($state == DOKU_LEXER_ENTER){
             $match = trim(substr($match,4,-1)); // strip markup
         } else if ($state == DOKU_LEXER_UNMATCHED) {
-            $handler->_addCall('cdata',array($match), $pos);
+            $handler->addCall('cdata',array($match), $pos);
             return false;
         }
         return array($state, $match);

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -30,7 +30,7 @@ class syntax_plugin_folded_span extends DokuWiki_Syntax_Plugin {
         if ($state == DOKU_LEXER_ENTER){
             $match = trim(substr($match,2,-1)); // strip markup
         } else if ($state == DOKU_LEXER_UNMATCHED) {
-            $handler->_addCall('cdata',array($match), $pos);
+            $handler->addCall('cdata',array($match), $pos);
             return false;
         }
         return array($state, $match);


### PR DESCRIPTION
On DokuWiki 2023-04-04a "Jack Jackrum", PHP 8.2.8 the following deprecation warnings are emitted:
`Doku_Handler::_addCall() is deprecated. It was called from syntax_plugin_folded_div::handle() in /var/www/admin-wiki/lib/plugins/folded/syntax/div.php:32 addCall should be used instead!`

This PR fixes these as well as the ones in `syntax/span.php`